### PR TITLE
Add CloudWatch Logs support

### DIFF
--- a/spec/inputs/kinesis/worker_spec.rb
+++ b/spec/inputs/kinesis/worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "LogStash::Inputs::Kinesis::Worker" do
   subject!(:worker) { LogStash::Inputs::Kinesis::Worker.new(codec, queue, decorator, checkpoint_interval) }
   let(:codec) { LogStash::Codecs::JSON.new() }
   let(:queue) { Queue.new }
-  let(:decorator) { proc { |x| x["decorated"] = true; x } }
+  let(:decorator) { proc { |x| x.set('decorated', true); x } }
   let(:checkpoint_interval) { 120 }
   let(:checkpointer) { double('checkpointer', checkpoint: nil) }
   let(:init_input) { KCL_TYPES::InitializationInput.new().withShardId("xyz") }
@@ -53,9 +53,9 @@ RSpec.describe "LogStash::Inputs::Kinesis::Worker" do
         m2 = queue.pop
         expect(m1).to be_kind_of(LogStash::Event)
         expect(m2).to be_kind_of(LogStash::Event)
-        expect(m1['id']).to eq("record1")
-        expect(m1['message']).to eq("test1")
-        expect(m1['decorated']).to eq(true)
+        expect(m1.get('id')).to eq("record1")
+        expect(m1.get('message')).to eq("test1")
+        expect(m1.get('decorated')).to eq(true)
       end
 
       it "checkpoints on interval" do


### PR DESCRIPTION
This is an initial attempt at adding support for CloudWatch Logs subscription data and general gzip-compressed records per https://github.com/logstash-plugins/logstash-input-kinesis/issues/2. I'm looking for feedback before cleaning up what's been done. This has been tested against live CloudWatch Logs data.

This PR presents two new configuration options, `compression` and `cloudwatch_logs`. Their defaults maintain the plugin's current behavior.

The `compression` option accepts nil or "gzip." When nil, the plugin's original behavior is retained. When set to "gzip," the plugin decompresses each record with gzip. 

When `cloudwatch_logs` is set to true, each record is split on its logEvents field. The end result is n events containing the original record's logGroup, logStream, messageType, owner, and subscriptionFilters fields merged with each logEvents document. The original logEvents field is removed from each split event. When `cloudwatch_logs` is true, `compression` must be set to `gzip`.