### PR TITLE
Bump Kinesis Client to version 1.7.0

### DIFF
--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.6.1'"
-  spec.requirements << "jar 'org.apache.httpcomponents:httpclient', '4.5.1'"
+  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.7.0'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.16'"
 
   spec.add_development_dependency 'jar-dependencies', '0.3.2'
 


### PR DESCRIPTION
This PR updates the Kinesis Client dependency to the latest version, 1.7.0.

It also bumps the `aws-java-sdk-core` version from 1.11.14 to 1.11.16 to support running Logstash on ECS using IAM Task Roles.