### PR TITLE
Fix build fails with logstash 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 vendor/
+/*.gem

--- a/Rakefile
+++ b/Rakefile
@@ -11,12 +11,9 @@ task default: "spec"
 require 'jars/installer'
 desc 'Install the JAR dependencies to vendor/'
 task :install_jars do
-  # If we don't have these env variables set, jar-dependencies will
-  # download the jars and place it in $PWD/lib/. We actually want them in
-  # $PWD/vendor
-  ENV['JARS_HOME'] = Dir.pwd + "/vendor/jar-dependencies/runtime-jars"
-  ENV['JARS_VENDOR'] = "false"
-  Jars::Installer.new.vendor_jars!(false)
+  # We actually want jar-dependencies will download the jars and place it in
+  # vendor/jar-dependencies/runtime-jars
+  Jars::Installer.new.vendor_jars!(false, 'vendor/jar-dependencies/runtime-jars')
 end
 
 task build: :install_jars

--- a/lib/logstash-input-kinesis_jars.rb
+++ b/lib/logstash-input-kinesis_jars.rb
@@ -1,5 +1,0 @@
-# encoding: utf-8
-require 'logstash/environment'
-
-root_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
-LogStash::Environment.load_runtime_jars! File.join(root_dir, "vendor")

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -55,8 +55,13 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
   def register
     # the INFO log level is extremely noisy in KCL
-    org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
+    if LOGSTASH_VERSION.to_f >= 5.0
+      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
+      logger.setLevel(org.apache.log4j::Level::WARN)
+    else
+      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
       logger.setLevel(java.util.logging::Level::WARNING)
+    end
 
     worker_id = java.util::UUID.randomUUID.to_s
     creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib', 'vendor/jar-dependencies/runtime-jars']
 
   # Special flag to let us know this is actually a logstash plugin
   spec.metadata      = { "logstash_plugin" => "true", "logstash_group" => "input" }
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   spec.add_development_dependency 'logstash-devutils'
-  spec.add_development_dependency 'jar-dependencies', '0.3.2'
+  spec.add_development_dependency 'jar-dependencies', '~> 0.3.4'
   spec.add_development_dependency "logstash-codec-json"
 end


### PR DESCRIPTION
This PR fix issue #10 build fails with logstash 5.0.
I tested with logstash version 2.4.0 and 5.0.0.