### PR TITLE
Fix error with logstash 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 vendor/
+/*.gem

--- a/Rakefile
+++ b/Rakefile
@@ -14,13 +14,7 @@ desc 'Install the JAR dependencies to vendor/'
 task :install_jars do
   # We actually want jar-dependencies will download the jars and place it in
   # vendor/jar-dependencies/runtime-jars
-  if Gem::Version.new(Jars::VERSION) >= Gem::Version.new('0.3.4')
-    Jars::Installer.new.vendor_jars!(false, 'vendor/jar-dependencies/runtime-jars')
-  else
-  	ENV['JARS_HOME'] = Dir.pwd + "/vendor/jar-dependencies/runtime-jars"
-  	ENV['JARS_VENDOR'] = "false"
-  	Jars::Installer.new.vendor_jars!(false)
-  end
+  Jars::Installer.new.vendor_jars!(false, 'vendor/jar-dependencies/runtime-jars')
 end
 
 task build: :install_jars

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "bundler/gem_tasks"
+require 'jars/version'
 
 begin
   require 'rspec/core/rake_task'
@@ -11,12 +12,15 @@ task default: "spec"
 require 'jars/installer'
 desc 'Install the JAR dependencies to vendor/'
 task :install_jars do
-  # If we don't have these env variables set, jar-dependencies will
-  # download the jars and place it in $PWD/lib/. We actually want them in
-  # $PWD/vendor
-  ENV['JARS_HOME'] = Dir.pwd + "/vendor/jar-dependencies/runtime-jars"
-  ENV['JARS_VENDOR'] = "false"
-  Jars::Installer.new.vendor_jars!(false)
+  # We actually want jar-dependencies will download the jars and place it in
+  # vendor/jar-dependencies/runtime-jars
+  if Gem::Version.new(Jars::VERSION) >= Gem::Version.new('0.3.4')
+    Jars::Installer.new.vendor_jars!(false, 'vendor/jar-dependencies/runtime-jars')
+  else
+  	ENV['JARS_HOME'] = Dir.pwd + "/vendor/jar-dependencies/runtime-jars"
+  	ENV['JARS_VENDOR'] = "false"
+  	Jars::Installer.new.vendor_jars!(false)
+  end
 end
 
 task build: :install_jars

--- a/lib/logstash-input-kinesis_jars.rb
+++ b/lib/logstash-input-kinesis_jars.rb
@@ -1,5 +1,0 @@
-# encoding: utf-8
-require 'logstash/environment'
-
-root_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
-LogStash::Environment.load_runtime_jars! File.join(root_dir, "vendor")

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -3,9 +3,11 @@ require "logstash/inputs/base"
 require "logstash/errors"
 require "logstash/environment"
 require "logstash/namespace"
+require 'logstash-core-plugin-api/version'
 
 require 'logstash-input-kinesis_jars'
 require "logstash/inputs/kinesis/version"
+
 
 # Receive events through an AWS Kinesis stream.
 #
@@ -55,8 +57,13 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
   def register
     # the INFO log level is extremely noisy in KCL
-    org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
-      logger.setLevel(java.util.logging::Level::WARNING)
+    if Gem::Version.new(LOGSTASH_CORE_PLUGIN_API) > Gem::Version.new('2.1.12')
+      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
+        logger.setLevel(org.apache.log4j::Level::WARN)
+    else
+      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
+        logger.setLevel(java.util.logging::Level::WARNING)
+    end
 
     worker_id = java.util::UUID.randomUUID.to_s
     creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib', 'vendor/jar-dependencies/runtime-jars']
 
   # Special flag to let us know this is actually a logstash plugin
   spec.metadata      = { "logstash_plugin" => "true", "logstash_group" => "input" }
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   spec.add_development_dependency 'logstash-devutils'
-  spec.add_development_dependency 'jar-dependencies', '0.3.2'
+  spec.add_development_dependency 'jar-dependencies', '~> 0.3.4'
   spec.add_development_dependency "logstash-codec-json"
 end


### PR DESCRIPTION
This PR fixed an error when executing with logstash-core-plugin-api version 2.1.16 on logstash 5.0. Because logstash-core-plugin-api 2.1.16 dependency jar-dependencies >= 0.3.4, I update jar-dependencies version to 0.3.4.
