### PR TITLE
Fix error with logstash 5.1.1

### DIFF
--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -3,7 +3,6 @@ require "logstash/inputs/base"
 require "logstash/errors"
 require "logstash/environment"
 require "logstash/namespace"
-require 'logstash-core-plugin-api/version'
 
 require 'logstash-input-kinesis_jars'
 require "logstash/inputs/kinesis/version"
@@ -57,12 +56,11 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
   def register
     # the INFO log level is extremely noisy in KCL
-    if Gem::Version.new(LOGSTASH_CORE_PLUGIN_API) > Gem::Version.new('2.1.12')
-      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
-        logger.setLevel(org.apache.log4j::Level::WARN)
+    kinesis_logger = org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").logger
+    if kinesis_logger.java_kind_of?(java.util.logging::Logger)
+      kinesis_logger.setLevel(java.util.logging::Level::WARNING)
     else
-      org.apache.commons.logging::LogFactory.getLog("com.amazonaws.services.kinesis").
-        logger.setLevel(java.util.logging::Level::WARNING)
+      kinesis_logger.setLevel(org.apache.log4j::Level::WARN)
     end
 
     worker_id = java.util::UUID.randomUUID.to_s

--- a/spec/inputs/kinesis/worker_spec.rb
+++ b/spec/inputs/kinesis/worker_spec.rb
@@ -1,3 +1,4 @@
+require 'logstash-core/logstash-core'
 require 'logstash-input-kinesis_jars'
 require "logstash/plugin"
 require "logstash/inputs/kinesis"


### PR DESCRIPTION
This PR fix issue #16. It is not a good idea to check the version numbers of logstash-core or logstash-core-plugin-api. I check whether class of logger of com.amazonaws.services.kinesis is java.util.logging::Logger or not.
