### PR TITLE
Add endpoint to config for testing and development

### DIFF
--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -50,6 +50,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   # to enable the cloudwatch integration in the Kinesis Client Library.
   config :metrics, :validate => [nil, "cloudwatch"], :default => nil
 
+  # Set kinesis endpoint for testing and development
+  config :kinesis_endpoint, :validate => :string, :default => nil
+
   def initialize(params = {})
     super(params)
   end
@@ -72,6 +75,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
       worker_id).
         withInitialPositionInStream(KCL::InitialPositionInStream::TRIM_HORIZON).
         withRegionName(@region)
+    if @kinesis_endpoint
+      @kcl_config = @kcl_config.withKinesisEndpoint(@kinesis_endpoint)
+    end
   end
 
   def run(output_queue)


### PR DESCRIPTION
I realized there's no way to set the endpoint if I am running Kinesis locally for testing and development. I couldn't get the local version of logstash-input-kinesis to run so I couldn't test it but code should work. If I can get a link to getting custom plugins to run locally that actually works I would really appreciate it!