### PR TITLE
Add profile property

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ This are the properties you can configure and what are the default values:
 * `metrics`: Worker metric tracking. By default this is disabled, set it to "cloudwatch" to enable the cloudwatch integration in the Kinesis Client Library.
     * **required**: false
     * **default value**: `nil`
+* `profile`: The AWS profile name for authentication. This ensures that the `~/.aws/credentials` AWS auth provider is used. By default this is empty and the default chain will be used.
+    * **required**: false
+    * **default value**: `""`    
 
 ## Authentication
 
-This plugin uses the default AWS SDK auth chain, [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), to determine which credentials the client will use.
+This plugin uses the default AWS SDK auth chain, [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), to determine which credentials the client will use, unless `profile` is set, in which case [ProfileCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html) is used.
 
 The default chain follows this order trying to read the credentials:
  * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_KEY` environment variables
@@ -61,7 +64,7 @@ The credentials will need access to the following services:
 * AWS DynamoDB: the client library stores information for worker coordination in DynamoDB (offsets and active worker per partition)
 * AWS CloudWatch: if the metrics are enabled the credentials need CloudWatch update permisions granted.
 
-Look at the [documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for deeper information.
+Look at the [documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for deeper information on the default chain.
 
 ## Contributing
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -49,6 +49,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-kinesis_stream_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-metrics>> |<<string,string>>, one of `[nil, "cloudwatch"]`|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-profile>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -57,7 +58,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-application_name"]
-===== `application_name` 
+===== `application_name`
 
   * Value type is <<string,string>>
   * Default value is `"logstash"`
@@ -66,7 +67,7 @@ The application name used for the dynamodb coordination table. Must be
 unique for this kinesis stream.
 
 [id="plugins-{type}s-{plugin}-checkpoint_interval_seconds"]
-===== `checkpoint_interval_seconds` 
+===== `checkpoint_interval_seconds`
 
   * Value type is <<number,number>>
   * Default value is `60`
@@ -74,7 +75,7 @@ unique for this kinesis stream.
 How many seconds between worker checkpoints to dynamodb.
 
 [id="plugins-{type}s-{plugin}-kinesis_stream_name"]
-===== `kinesis_stream_name` 
+===== `kinesis_stream_name`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -83,7 +84,7 @@ How many seconds between worker checkpoints to dynamodb.
 The kinesis stream name.
 
 [id="plugins-{type}s-{plugin}-metrics"]
-===== `metrics` 
+===== `metrics`
 
   * Value can be any of: ``, `cloudwatch`
   * Default value is `nil`
@@ -92,14 +93,22 @@ Worker metric tracking. By default this is disabled, set it to "cloudwatch"
 to enable the cloudwatch integration in the Kinesis Client Library.
 
 [id="plugins-{type}s-{plugin}-region"]
-===== `region` 
+===== `region`
 
   * Value type is <<string,string>>
   * Default value is `"us-east-1"`
 
 The AWS region for Kinesis, DynamoDB, and CloudWatch (if enabled)
 
+[id="plugins-{type}s-{plugin}-profile"]
+===== `profile`
 
+  * Value type is <<string,string>>
+  * Default value is `nil`
+
+The AWS profile name for authentication.
+This ensures that the `~/.aws/credentials` AWS auth provider is used.
+By default this is empty and the default chain will be used.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -51,7 +51,7 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   config :metrics, :validate => [nil, "cloudwatch"], :default => nil
 
   # Select AWS profile for input
-  config :profile, :validate => :string, :default => ""
+  config :profile, :validate => :string
 
   def initialize(params = {})
     super(params)
@@ -70,8 +70,8 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
     # If the AWS profile is set, use the profile credentials provider.
     # Otherwise fall back to the default chain.
-    unless @profile.empty?
-      creds = com.amazonaws.auth.profile::ProfileCredentialsProvider.new(String @profile)
+    unless @profile.nil?
+      creds = com.amazonaws.auth.profile::ProfileCredentialsProvider.new(@profile)
     else
       creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new
     end

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -70,7 +70,7 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
     # If the AWS profile is set, use the profile credentials provider.
     # Otherwise fall back to the default chain.
-    unless @profile.empty? do
+    unless @profile.empty?
       creds = com.amazonaws.auth.profile::ProfileCredentialsProvider.new(String @profile)
     else
       creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -50,6 +50,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   # to enable the cloudwatch integration in the Kinesis Client Library.
   config :metrics, :validate => [nil, "cloudwatch"], :default => nil
 
+  # Select AWS profile for input
+  config :profile, :validate => :string, :default => ""
+
   def initialize(params = {})
     super(params)
   end
@@ -64,7 +67,14 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
     end
 
     worker_id = java.util::UUID.randomUUID.to_s
-    creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new
+
+    # If the AWS profile is set, use the profile credentials provider.
+    # Otherwise fall back to the default chain.
+    unless @profile.empty? do
+      creds = com.amazonaws.auth.profile::ProfileCredentialsProvider.new(String @profile)
+    else
+      creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new
+    end
     @kcl_config = KCL::KinesisClientLibConfiguration.new(
       @application_name,
       @kinesis_stream_name,

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -2,27 +2,6 @@ require "logstash/plugin"
 require "logstash/inputs/kinesis"
 require "logstash/codecs/json"
 
-KCL2 = com.amazonaws.services.kinesis.clientlibrary.lib.worker
-
-config2={
-  "application_name" => "my-processor",
-  "kinesis_stream_name" => "run-specs",
-  "codec" => LogStash::Codecs::JSON.new(),
-  "metrics" => nil,
-  "checkpoint_interval_seconds" => 120,
-  "region" => "ap-southeast-1",
-}
-
-kinesis2=LogStash::Inputs::Kinesis.new(config2)
-kinesis2.register
-
-puts kinesis2.kcl_config.get_kinesis_credentials_provider.getClass.to_s
-if kinesis2.kcl_config.get_kinesis_credentials_provider.getClass.to_s == "com.amazonaws.auth.profile.ProfileCredentialsProvider"
-  puts "tes"
-else
-  puts "nes"
-end
-
 RSpec.describe "inputs/kinesis" do
   KCL = com.amazonaws.services.kinesis.clientlibrary.lib.worker
 


### PR DESCRIPTION
Add profile option for allowing authentication with AWS Shared Credentials file with a named profile.

Allows authenticating with multiple AWS accounts by the same Logstash process.