### PR TITLE
Standardize the build of the plugins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,3 +18,4 @@ task :install_jars do
 end
 
 task build: :install_jars
+task vendor: :install_jars


### PR DESCRIPTION
Default plugins relies on the existance of the `rake vendor` task to
make sure that all the artifacts are present for the tests, to make this
plugin compatible we will just alias the vendor task to install_jars