### PR TITLE
Add publish task to the plugin so Jarvis can publish it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,6 @@ task :install_jars do
 end
 
 task build: :install_jars
+require "logstash/devutils/rake"
 task vendor: :install_jars
+


### PR DESCRIPTION
The plugin was missing the `rake publish_gem` task, so our bot was not
able to publish it.