### PR TITLE
Update Kinesis client library and AWS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Changed plugin to use more recent versions of Kinesis Client library and AWS SDK
+
 ## 2.0.7
   - Docs: Set the default_codec doc attribute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## Unreleased
-  - Changed plugin to use more recent versions of Kinesis Client library and AWS SDK
+## 2.0.8
+  - Changed plugin to use more recent versions of Kinesis Client library and AWS SDK[#45](https://github.com/logstash-plugins/logstash-input-kinesis/pull/45)
 
 ## 2.0.7
   - Docs: Set the default_codec doc attribute.

--- a/lib/logstash/inputs/kinesis/version.rb
+++ b/lib/logstash/inputs/kinesis/version.rb
@@ -2,7 +2,7 @@
 module Logstash
   module Input
     module Kinesis
-      VERSION = "2.0.7"
+      VERSION = "2.0.8"
     end
   end
 end

--- a/lib/logstash/inputs/kinesis/worker.rb
+++ b/lib/logstash/inputs/kinesis/worker.rb
@@ -31,7 +31,7 @@ class LogStash::Inputs::Kinesis::Worker
   end
 
   def shutdown(shutdown_input)
-    if shutdown_input.shutdown_reason == com.amazonaws.services.kinesis.clientlibrary.types::ShutdownReason::TERMINATE
+    if shutdown_input.shutdown_reason == com.amazonaws.services.kinesis.clientlibrary.lib.worker::ShutdownReason::TERMINATE
       checkpoint(shutdown_input.checkpointer)
     end
   end

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Receives events through an AWS Kinesis stream"
   spec.description   = %q{This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program}
   spec.homepage      = "https://github.com/logstash-plugins/logstash-input-kinesis"
-  spec.licenses      = ['Apache License (2.0)']
+  spec.licenses      = ['Apache-2.0']
 
   spec.files         = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.7.0'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.16'"
+  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.9.2'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'"
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 

--- a/spec/inputs/kinesis/worker_spec.rb
+++ b/spec/inputs/kinesis/worker_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "LogStash::Inputs::Kinesis::Worker" do
         checkpointer = double('checkpointer')
         expect(checkpointer).to receive(:checkpoint)
         input.
-          with_shutdown_reason(KCL_TYPES::ShutdownReason::TERMINATE).
+          with_shutdown_reason(com.amazonaws.services.kinesis.clientlibrary.lib.worker::ShutdownReason::TERMINATE).
           with_checkpointer(checkpointer)
         worker.shutdown(input)
       end


### PR DESCRIPTION
Use most recent version of 1.x Kinesis client library and 1.11 AWS Java SDK