### PR TITLE
Add configurable failover_time_millis and default to 120s (double the default checkpoint time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ This are the properties you can configure and what are the default values:
 * `checkpoint_interval_seconds`: How many seconds between worker checkpoints to DynamoDB. A low value ussually means lower message replay in case of node failure/restart but it increases CPU+network ussage (which increases the AWS costs).
     * **required**: false
     * **default value**: `60`
+* `failover_time_millis`: How many milliseconds to wait since the last checkpoint before a new worker should take over the lease.
+    * **required**: false
+    * **default value**: `120000`
 * `metrics`: Worker metric tracking. By default this is disabled, set it to "cloudwatch" to enable the cloudwatch integration in the Kinesis Client Library.
     * **required**: false
     * **default value**: `nil`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-application_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-checkpoint_interval_seconds>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-failover_time_millis>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-kinesis_stream_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-metrics>> |<<string,string>>, one of `[nil, "cloudwatch"]`|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
@@ -72,6 +73,14 @@ unique for this kinesis stream.
   * Default value is `60`
 
 How many seconds between worker checkpoints to dynamodb.
+
+[id="plugins-{type}s-{plugin}-failover_time_millis"]
+===== `failover_time_millis`
+
+  * Value type is <<number,number>>
+  * Default value is `120000`
+
+How many milliseconds to wait since the last checkpoint before a new worker should take over the lease.
 
 [id="plugins-{type}s-{plugin}-kinesis_stream_name"]
 ===== `kinesis_stream_name`

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -46,6 +46,10 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   # How many seconds between worker checkpoints to dynamodb.
   config :checkpoint_interval_seconds, :validate => :number, :default => 60
 
+  # How many milliseconds to wait since the last checkpoint before a new
+  # worker should take over the lease.
+  config :failover_time_millis, :validate => :number, :default => 120000
+
   # Worker metric tracking. By default this is disabled, set it to "cloudwatch"
   # to enable the cloudwatch integration in the Kinesis Client Library.
   config :metrics, :validate => [nil, "cloudwatch"], :default => nil
@@ -90,7 +94,8 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
       creds,
       worker_id).
         withInitialPositionInStream(initial_position_in_stream).
-        withRegionName(@region)
+        withRegionName(@region).
+        withFailoverTimeMillis(@failover_time_millis)
   end
 
   def run(output_queue)


### PR DESCRIPTION
This currently defaults to 10s but the default checkpoint time is 60s so if more than one logstash instance is reading from the stream loads of "Can't update checkpoint - instance doesn't hold the lease for this shard" errors are thrown.