### PR TITLE
Add the ability to set arbitrary KCL configurations that are exposed through KinesisClientLibConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This are the properties you can configure and what are the default values:
     * **required**: false
     * **default value**: `"TRIM_HORIZON"`
 
-### Additional KCL Configurations
-* `additional_kcl_options`: The KCL provides several configuration options which can be set in [KinesisClientLibConfiguration](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java). These options are configured via various function calls that all begin with `with`. Some of these functions take complex types, which are not supported. However, you may invoke any one of the `withX()` functions that take a primitive by providing key-value pairs in `snake_case`. For example, to set the dynamodb read and write capacity values, two functions exist, withInitialLeaseTableReadCapacity and withInitialLeaseTableWriteCapacity. To set a value for these, provide a hash of `additional_kcl_options => {"initial_lease_table_read_capacity" => 25, "initial_lease_table_write_capacity" => 100}`
+### Additional KCL Settings
+* `additional_settings`: The KCL provides several configuration options which can be set in [KinesisClientLibConfiguration](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java). These options are configured via various function calls that all begin with `with`. Some of these functions take complex types, which are not supported. However, you may invoke any one of the `withX()` functions that take a primitive by providing key-value pairs in `snake_case`. For example, to set the dynamodb read and write capacity values, two functions exist, withInitialLeaseTableReadCapacity and withInitialLeaseTableWriteCapacity. To set a value for these, provide a hash of `additional_settings => {"initial_lease_table_read_capacity" => 25, "initial_lease_table_write_capacity" => 100}`
     * **required**: false
     * **default value**: `{}`
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ This are the properties you can configure and what are the default values:
     * **required**: false
     * **default value**: `"TRIM_HORIZON"`
 
+### Additional KCL Configurations
+* `additional_kcl_options`: The KCL provides several configuration options which can be set in [KinesisClientLibConfiguration](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java). These options are configured via various function calls that all begin with `with`. Some of these functions take complex types, which are not supported. However, you may invoke any one of the `withX()` functions that take a primitive by providing key-value pairs in `snake_case`. For example, to set the dynamodb read and write capacity values, two functions exist, withInitialLeaseTableReadCapacity and withInitialLeaseTableWriteCapacity. To set a value for these, provide a hash of `additional_kcl_options => {"initial_lease_table_read_capacity" => 25, "initial_lease_table_write_capacity" => 100}`
+    * **required**: false
+    * **default value**: `{}`
+
 ## Authentication
 
 This plugin uses the default AWS SDK auth chain, [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), to determine which credentials the client will use, unless `profile` is set, in which case [ProfileCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html) is used.

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -96,10 +96,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
         withRegionName(@region)
 
       # Call arbitrary "withX()" functions
-      # replace snake_case => withCamelCase
-      # e.g. initial_position_in_stream => withInitialPositionInStream
+      # snake_case => withCamelCase happens automatically
       @additional_kcl_options.each do |key, value|
-          fn = 'with' + key.title().replace('_', '')
+          fn = "with_#{key}"
           @kcl_config.send(fn, value)
       end
   end

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -56,6 +56,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   # Select initial_position_in_stream. Accepts TRIM_HORIZON or LATEST
   config :initial_position_in_stream, :validate => ["TRIM_HORIZON", "LATEST"], :default => "TRIM_HORIZON"
 
+  # Any additional arbitrary kcl options configurable in the KinesisClientLibConfiguration
+  config :additional_kcl_options, :validate => :hash, :default => {}
+
   def initialize(params = {})
     super(params)
   end
@@ -91,6 +94,14 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
       worker_id).
         withInitialPositionInStream(initial_position_in_stream).
         withRegionName(@region)
+
+      # Call arbitrary "withX()" functions
+      # replace snake_case => withCamelCase
+      # e.g. initial_position_in_stream => withInitialPositionInStream
+      @additional_kcl_options.each do |key, value|
+          fn = 'with' + key.title().replace('_', '')
+          @kcl_config.send(fn, value)
+      end
   end
 
   def run(output_queue)

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -57,7 +57,7 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   config :initial_position_in_stream, :validate => ["TRIM_HORIZON", "LATEST"], :default => "TRIM_HORIZON"
 
   # Any additional arbitrary kcl options configurable in the KinesisClientLibConfiguration
-  config :additional_kcl_options, :validate => :hash, :default => {}
+  config :additional_settings, :validate => :hash, :default => {}
 
   def initialize(params = {})
     super(params)
@@ -97,7 +97,7 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
 
       # Call arbitrary "withX()" functions
       # snake_case => withCamelCase happens automatically
-      @additional_kcl_options.each do |key, value|
+      @additional_settings.each do |key, value|
           fn = "with_#{key}"
           @kcl_config.send(fn, value)
       end

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -134,6 +134,20 @@ RSpec.describe "inputs/kinesis" do
   end
 
 
+  subject!(:kinesis_with_invalid_additional_kcl_options_name_not_found) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_kcl_options_name_not_found) }
+
+  it "raises NoMethodError for invalid configuration options" do
+    expect{ kinesis_with_invalid_additional_kcl_options_name_not_found.register }.to raise_error(NoMethodError)
+  end
+
+
+  subject!(:kinesis_with_invalid_additional_kcl_options_wrong_type) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_kcl_options_wrong_type) }
+
+  it "raises an error for invalid configuration values such as the wrong type" do
+    expect{ kinesis_with_invalid_additional_kcl_options_wrong_type.register }.to raise_error(Java::JavaLang::IllegalArgumentException)
+  end
+
+
   context "#run" do
     it "runs the KCL worker" do
       expect(kinesis).to receive(:kcl_builder).with(queue).and_return(stub_builder)

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "inputs/kinesis" do
     "additional_kcl_options" => {
         "initial_lease_table_read_capacity" => 25,
         "initial_lease_table_write_capacity" => 100,
-        "kinesis_endpoint" => "http://www.localhost"
+        "kinesis_endpoint" => "http://localhost"
     }
   }}
 
@@ -124,13 +124,13 @@ RSpec.describe "inputs/kinesis" do
   subject!(:kinesis_with_valid_additional_kcl_options) { LogStash::Inputs::Kinesis.new(config_with_valid_additional_kcl_options) }
 
   it "configures the KCL" do
-    kinesis_with_latest.register
-    expect(kinesis_with_latest.kcl_config.applicationName).to eq("my-processor")
-    expect(kinesis_with_latest.kcl_config.streamName).to eq("run-specs")
-    expect(kinesis_with_latest.kcl_config.regionName).to eq("ap-southeast-1")
-    expect(kinesis_with_latest.kcl_config.initialLeaseTableReadCapacity).to eq(25)
-    expect(kinesis_with_latest.kcl_config.initialLeaseTableWriteCapacity).to eq(100)
-    expect(kinesis_with_latest.kcl_config.kinesisEndpoint).to eq("http://localhost")
+    kinesis_with_valid_additional_kcl_options.register
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.applicationName).to eq("my-processor")
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.streamName).to eq("run-specs")
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.regionName).to eq("ap-southeast-1")
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.initialLeaseTableReadCapacity).to eq(25)
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.initialLeaseTableWriteCapacity).to eq(100)
+    expect(kinesis_with_valid_additional_kcl_options.kcl_config.kinesisEndpoint).to eq("http://localhost")
   end
 
 

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "inputs/kinesis" do
     "initial_position_in_stream" => "LATEST"
   }}
 
-  # Config hash to test valid additional_kcl_options
-  let(:config_with_valid_additional_kcl_options) {{
+  # Config hash to test valid additional_settings
+  let(:config_with_valid_additional_settings) {{
     "application_name" => "my-processor",
     "kinesis_stream_name" => "run-specs",
     "codec" => codec,
@@ -47,15 +47,15 @@ RSpec.describe "inputs/kinesis" do
     "checkpoint_interval_seconds" => 120,
     "region" => "ap-southeast-1",
     "profile" => nil,
-    "additional_kcl_options" => {
+    "additional_settings" => {
         "initial_lease_table_read_capacity" => 25,
         "initial_lease_table_write_capacity" => 100,
         "kinesis_endpoint" => "http://localhost"
     }
   }}
 
-  # Config hash to test invalid additional_kcl_options where the name is not found
-  let(:config_with_invalid_additional_kcl_options_name_not_found) {{
+  # Config hash to test invalid additional_settings where the name is not found
+  let(:config_with_invalid_additional_settings_name_not_found) {{
     "application_name" => "my-processor",
     "kinesis_stream_name" => "run-specs",
     "codec" => codec,
@@ -63,13 +63,13 @@ RSpec.describe "inputs/kinesis" do
     "checkpoint_interval_seconds" => 120,
     "region" => "ap-southeast-1",
     "profile" => nil,
-    "additional_kcl_options" => {
+    "additional_settings" => {
         "foo" => "bar"
     }
   }}
 
-  # Config hash to test invalid additional_kcl_options where the type is complex or wrong
-  let(:config_with_invalid_additional_kcl_options_wrong_type) {{
+  # Config hash to test invalid additional_settings where the type is complex or wrong
+  let(:config_with_invalid_additional_settings_wrong_type) {{
     "application_name" => "my-processor",
     "kinesis_stream_name" => "run-specs",
     "codec" => codec,
@@ -77,7 +77,7 @@ RSpec.describe "inputs/kinesis" do
     "checkpoint_interval_seconds" => 120,
     "region" => "ap-southeast-1",
     "profile" => nil,
-    "additional_kcl_options" => {
+    "additional_settings" => {
         "metrics_level" => "invalid_metrics_level"
     }
   }}
@@ -121,30 +121,30 @@ RSpec.describe "inputs/kinesis" do
     expect(kinesis_with_latest.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
   end
 
-  subject!(:kinesis_with_valid_additional_kcl_options) { LogStash::Inputs::Kinesis.new(config_with_valid_additional_kcl_options) }
+  subject!(:kinesis_with_valid_additional_settings) { LogStash::Inputs::Kinesis.new(config_with_valid_additional_settings) }
 
   it "configures the KCL" do
-    kinesis_with_valid_additional_kcl_options.register
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.applicationName).to eq("my-processor")
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.streamName).to eq("run-specs")
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.regionName).to eq("ap-southeast-1")
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.initialLeaseTableReadCapacity).to eq(25)
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.initialLeaseTableWriteCapacity).to eq(100)
-    expect(kinesis_with_valid_additional_kcl_options.kcl_config.kinesisEndpoint).to eq("http://localhost")
+    kinesis_with_valid_additional_settings.register
+    expect(kinesis_with_valid_additional_settings.kcl_config.applicationName).to eq("my-processor")
+    expect(kinesis_with_valid_additional_settings.kcl_config.streamName).to eq("run-specs")
+    expect(kinesis_with_valid_additional_settings.kcl_config.regionName).to eq("ap-southeast-1")
+    expect(kinesis_with_valid_additional_settings.kcl_config.initialLeaseTableReadCapacity).to eq(25)
+    expect(kinesis_with_valid_additional_settings.kcl_config.initialLeaseTableWriteCapacity).to eq(100)
+    expect(kinesis_with_valid_additional_settings.kcl_config.kinesisEndpoint).to eq("http://localhost")
   end
 
 
-  subject!(:kinesis_with_invalid_additional_kcl_options_name_not_found) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_kcl_options_name_not_found) }
+  subject!(:kinesis_with_invalid_additional_settings_name_not_found) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_settings_name_not_found) }
 
   it "raises NoMethodError for invalid configuration options" do
-    expect{ kinesis_with_invalid_additional_kcl_options_name_not_found.register }.to raise_error(NoMethodError)
+    expect{ kinesis_with_invalid_additional_settings_name_not_found.register }.to raise_error(NoMethodError)
   end
 
 
-  subject!(:kinesis_with_invalid_additional_kcl_options_wrong_type) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_kcl_options_wrong_type) }
+  subject!(:kinesis_with_invalid_additional_settings_wrong_type) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_settings_wrong_type) }
 
   it "raises an error for invalid configuration values such as the wrong type" do
-    expect{ kinesis_with_invalid_additional_kcl_options_wrong_type.register }.to raise_error(Java::JavaLang::IllegalArgumentException)
+    expect{ kinesis_with_invalid_additional_settings_wrong_type.register }.to raise_error(Java::JavaLang::IllegalArgumentException)
   end
 
 


### PR DESCRIPTION
Add the ability to set arbitrary KCL configurations that are exposed through `KinesisClientLibConfiguration`

I was going to add the explicit plumbing for another config parameter, and then I noticed that #50 by @w4 was doing the same thing, and I saw how many more potential configuration options there were that somebody might want to pass through. So I decided to generalize this so that any of those "with" functions can be called (so long as they only accept primitives and so long as you give it the correct type!).