### PR TITLE
Upgrade to KCL v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ This are the properties you can configure and what are the default values:
     * **required**: false
     * **default value**: `"TRIM_HORIZON"`
 
+### Additional KCL Settings
+
+Each configuration value defined in the KCL config files given below can be passed as snake_case, for example to set `initialLeaseTableReadCapacity` in `LeaseManagementConfig` to 30 the following configuration block could be used: `"lease_management_additional_settings" => { "initial_lease_table_read_capacity" => 30 }`
+
+* `checkpoint_additional_settings`: Configuration values to set in [CheckpointConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/CheckpointConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `coordinator_additional_settings`: Configuration values to set in [CoordinatorConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/CoordinatorConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `lease_management_additional_settings`: Configuration values to set in [LeaseManagementConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `lifecycle_additional_settings`: Configuration values to set in [LifecycleConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LifecycleConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `metrics_additional_settings`: Configuration values to set in [MetricsConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `retrieval_additional_settings`: Configuration values to set in [RetrievalConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+* `processor_additional_settings`: Configuration values to set in [ProcessorConfig](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/ProcessorConfig.java).
+    * **required**: false
+    * **default value**: `{}`
+
 ## Authentication
 
 This plugin uses the default AWS SDK auth chain, [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), to determine which credentials the client will use, unless `profile` is set, in which case [ProfileCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html) is used.

--- a/README.md
+++ b/README.md
@@ -53,11 +53,6 @@ This are the properties you can configure and what are the default values:
     * **required**: false
     * **default value**: `"TRIM_HORIZON"`
 
-### Additional KCL Settings
-* `additional_settings`: The KCL provides several configuration options which can be set in [KinesisClientLibConfiguration](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java). These options are configured via various function calls that all begin with `with`. Some of these functions take complex types, which are not supported. However, you may invoke any one of the `withX()` functions that take a primitive by providing key-value pairs in `snake_case`. For example, to set the dynamodb read and write capacity values, two functions exist, withInitialLeaseTableReadCapacity and withInitialLeaseTableWriteCapacity. To set a value for these, provide a hash of `additional_settings => {"initial_lease_table_read_capacity" => 25, "initial_lease_table_write_capacity" => 100}`
-    * **required**: false
-    * **default value**: `{}`
-
 ## Authentication
 
 This plugin uses the default AWS SDK auth chain, [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), to determine which credentials the client will use, unless `profile` is set, in which case [ProfileCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html) is used.

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.9.2'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'"
+  spec.requirements << "jar 'software.amazon.kinesis:amazon-kinesis-client', '2.0.4'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'" 
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   spec.add_development_dependency 'logstash-devutils'
-  spec.add_development_dependency 'jar-dependencies', '~> 0.3.4'
+  spec.add_development_dependency 'jar-dependencies', '~> 0.4.0'
   spec.add_development_dependency "logstash-codec-json"
 end

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'software.amazon.kinesis:amazon-kinesis-client', '2.0.4'"
+  spec.requirements << "jar 'software.amazon.kinesis:amazon-kinesis-client', '2.0.5'"
   spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'" 
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -3,7 +3,7 @@ require "logstash/inputs/kinesis"
 require "logstash/codecs/json"
 
 RSpec.describe "inputs/kinesis" do
-  KCL = com.amazonaws.services.kinesis.clientlibrary.lib.worker
+  KCL = software.amazon.kinesis.common
 
   let(:config) {{
     "application_name" => "my-processor",
@@ -38,56 +38,13 @@ RSpec.describe "inputs/kinesis" do
     "initial_position_in_stream" => "LATEST"
   }}
 
-  # Config hash to test valid additional_settings
-  let(:config_with_valid_additional_settings) {{
-    "application_name" => "my-processor",
-    "kinesis_stream_name" => "run-specs",
-    "codec" => codec,
-    "metrics" => metrics,
-    "checkpoint_interval_seconds" => 120,
-    "region" => "ap-southeast-1",
-    "profile" => nil,
-    "additional_settings" => {
-        "initial_lease_table_read_capacity" => 25,
-        "initial_lease_table_write_capacity" => 100,
-        "kinesis_endpoint" => "http://localhost"
-    }
-  }}
-
-  # Config hash to test invalid additional_settings where the name is not found
-  let(:config_with_invalid_additional_settings_name_not_found) {{
-    "application_name" => "my-processor",
-    "kinesis_stream_name" => "run-specs",
-    "codec" => codec,
-    "metrics" => metrics,
-    "checkpoint_interval_seconds" => 120,
-    "region" => "ap-southeast-1",
-    "profile" => nil,
-    "additional_settings" => {
-        "foo" => "bar"
-    }
-  }}
-
-  # Config hash to test invalid additional_settings where the type is complex or wrong
-  let(:config_with_invalid_additional_settings_wrong_type) {{
-    "application_name" => "my-processor",
-    "kinesis_stream_name" => "run-specs",
-    "codec" => codec,
-    "metrics" => metrics,
-    "checkpoint_interval_seconds" => 120,
-    "region" => "ap-southeast-1",
-    "profile" => nil,
-    "additional_settings" => {
-        "metrics_level" => "invalid_metrics_level"
-    }
-  }}
-
   subject!(:kinesis) { LogStash::Inputs::Kinesis.new(config) }
   let(:kcl_worker) { double('kcl_worker') }
-  let(:stub_builder) { double('kcl_builder', build: kcl_worker) }
   let(:metrics) { nil }
   let(:codec) { LogStash::Codecs::JSON.new() }
   let(:queue) { Queue.new }
+
+  subject!(:kinesis) { LogStash::Inputs::Kinesis.new(config) }
 
   it "registers without error" do
     input = LogStash::Plugin.lookup("input", "kinesis").new("kinesis_stream_name" => "specs", "codec" => codec)
@@ -98,72 +55,82 @@ RSpec.describe "inputs/kinesis" do
     kinesis.register
     expect(kinesis.kcl_config.applicationName).to eq("my-processor")
     expect(kinesis.kcl_config.streamName).to eq("run-specs")
-    expect(kinesis.kcl_config.regionName).to eq("ap-southeast-1")
-    expect(kinesis.kcl_config.initialPositionInStream).to eq(KCL::InitialPositionInStream::TRIM_HORIZON)
-    expect(kinesis.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+    expect(kinesis.retrieval_config.initialPositionInStreamExtended.initialPositionInStream).to eq(KCL::InitialPositionInStream::TRIM_HORIZON)
+
+    assert_client_region = -> (client) do
+      config = get_client_configuration client
+      expect(config.option(software.amazon.awssdk.awscore.client.config.AwsClientOption::AWS_REGION).to_s).to eq("ap-southeast-1")
+    end
+
+    assert_client_region.call kinesis.kcl_config.cloudWatchClient
+    assert_client_region.call kinesis.kcl_config.dynamoDBClient
+    assert_client_region.call kinesis.kcl_config.kinesisClient
+
+    assert_credentials_provider = -> (client) do
+      config = get_client_configuration client
+      expect(config.option(software.amazon.awssdk.awscore.client.config.AwsClientOption::CREDENTIALS_PROVIDER).getClass.to_s).to eq("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider")
+    end
+
+    assert_credentials_provider.call kinesis.kcl_config.cloudWatchClient
+    assert_credentials_provider.call kinesis.kcl_config.dynamoDBClient
+    assert_credentials_provider.call kinesis.kcl_config.kinesisClient
   end
 
   subject!(:kinesis_with_profile) { LogStash::Inputs::Kinesis.new(config_with_profile) }
 
   it "uses ProfileCredentialsProvider if profile is specified" do
     kinesis_with_profile.register
-    expect(kinesis_with_profile.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.profile.ProfileCredentialsProvider")
+
+    assert_credentials_provider = -> (client) do
+      config = get_client_configuration client
+      expect(config.option(software.amazon.awssdk.awscore.client.config.AwsClientOption::CREDENTIALS_PROVIDER).getClass.to_s).to eq("software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider")
+	end
+
+    assert_credentials_provider.call kinesis_with_profile.kcl_config.cloudWatchClient
+    assert_credentials_provider.call kinesis_with_profile.kcl_config.dynamoDBClient
+    assert_credentials_provider.call kinesis_with_profile.kcl_config.kinesisClient
   end
 
   subject!(:kinesis_with_latest) { LogStash::Inputs::Kinesis.new(config_with_latest) }
 
   it "configures the KCL" do
-    kinesis_with_latest.register
-    expect(kinesis_with_latest.kcl_config.applicationName).to eq("my-processor")
-    expect(kinesis_with_latest.kcl_config.streamName).to eq("run-specs")
-    expect(kinesis_with_latest.kcl_config.regionName).to eq("ap-southeast-1")
-    expect(kinesis_with_latest.kcl_config.initialPositionInStream).to eq(KCL::InitialPositionInStream::LATEST)
-    expect(kinesis_with_latest.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+     kinesis_with_latest.register
+
+     expect(kinesis_with_latest.kcl_config.applicationName).to eq("my-processor")
+     expect(kinesis_with_latest.kcl_config.streamName).to eq("run-specs")
+     expect(kinesis_with_latest.retrieval_config.initialPositionInStreamExtended.initialPositionInStream).to eq(KCL::InitialPositionInStream::LATEST)
+
+     assert_client_region = -> (client) do
+       config = get_client_configuration client
+       expect(config.option(software.amazon.awssdk.awscore.client.config.AwsClientOption::AWS_REGION).to_s).to eq("ap-southeast-1")
+     end
+
+     assert_client_region.call kinesis_with_latest.kcl_config.cloudWatchClient
+     assert_client_region.call kinesis_with_latest.kcl_config.dynamoDBClient
+     assert_client_region.call kinesis_with_latest.kcl_config.kinesisClient
+
+     assert_credentials_provider = -> (client) do
+       config = get_client_configuration client
+       expect(config.option(software.amazon.awssdk.awscore.client.config.AwsClientOption::CREDENTIALS_PROVIDER).getClass.to_s).to eq("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider")
+     end
+
+     assert_credentials_provider.call kinesis_with_latest.kcl_config.cloudWatchClient
+     assert_credentials_provider.call kinesis_with_latest.kcl_config.dynamoDBClient
+     assert_credentials_provider.call kinesis_with_latest.kcl_config.kinesisClient
   end
 
-  subject!(:kinesis_with_valid_additional_settings) { LogStash::Inputs::Kinesis.new(config_with_valid_additional_settings) }
-
-  it "configures the KCL" do
-    kinesis_with_valid_additional_settings.register
-    expect(kinesis_with_valid_additional_settings.kcl_config.applicationName).to eq("my-processor")
-    expect(kinesis_with_valid_additional_settings.kcl_config.streamName).to eq("run-specs")
-    expect(kinesis_with_valid_additional_settings.kcl_config.regionName).to eq("ap-southeast-1")
-    expect(kinesis_with_valid_additional_settings.kcl_config.initialLeaseTableReadCapacity).to eq(25)
-    expect(kinesis_with_valid_additional_settings.kcl_config.initialLeaseTableWriteCapacity).to eq(100)
-    expect(kinesis_with_valid_additional_settings.kcl_config.kinesisEndpoint).to eq("http://localhost")
+  it "starts the KCL worker" do
+    expect(kinesis).to receive(:kcl_builder).with(queue).and_return(kcl_worker)
+    expect(kcl_worker).to receive(:run).with(no_args)
+    kinesis.run(queue)
   end
 
-
-  subject!(:kinesis_with_invalid_additional_settings_name_not_found) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_settings_name_not_found) }
-
-  it "raises NoMethodError for invalid configuration options" do
-    expect{ kinesis_with_invalid_additional_settings_name_not_found.register }.to raise_error(NoMethodError)
-  end
-
-
-  subject!(:kinesis_with_invalid_additional_settings_wrong_type) { LogStash::Inputs::Kinesis.new(config_with_invalid_additional_settings_wrong_type) }
-
-  it "raises an error for invalid configuration values such as the wrong type" do
-    expect{ kinesis_with_invalid_additional_settings_wrong_type.register }.to raise_error(Java::JavaLang::IllegalArgumentException)
-  end
-
-
-  context "#run" do
-    it "runs the KCL worker" do
-      expect(kinesis).to receive(:kcl_builder).with(queue).and_return(stub_builder)
-      expect(kcl_worker).to receive(:run).with(no_args)
-      builder = kinesis.run(queue)
-    end
-  end
-
-  context "#stop" do
-    it "stops the KCL worker" do
-      expect(kinesis).to receive(:kcl_builder).with(queue).and_return(stub_builder)
-      expect(kcl_worker).to receive(:run).with(no_args)
-      expect(kcl_worker).to receive(:shutdown).with(no_args)
-      kinesis.run(queue)
-      kinesis.do_stop # do_stop calls stop internally
-    end
+  it "stops the KCL worker" do
+    expect(kinesis).to receive(:kcl_builder).with(queue).and_return(kcl_worker)
+    expect(kcl_worker).to receive(:run).with(no_args)
+    expect(kcl_worker).to receive(:start_graceful_shutdown).with(no_args).and_return(java.util.concurrent.CompletableFuture.completed_future(true))
+    kinesis.run(queue)
+    kinesis.do_stop # do_stop calls stop internally
   end
 
   context "#worker_factory" do
@@ -188,20 +155,22 @@ RSpec.describe "inputs/kinesis" do
   # these tests are heavily dependent on the current Worker::Builder
   # implementation because its state is all private
   context "#kcl_builder" do
-    let(:builder) { kinesis.kcl_builder(queue) }
+    let(:scheduler) {
+      kinesis.register
+      scheduler = kinesis.kcl_builder(queue)
+
+      # https://github.com/awslabs/amazon-kinesis-client/issues/464
+      scheduler.metrics_factory.shutdown if scheduler.metrics_factory.is_a?(software.amazon.kinesis.metrics::CloudWatchMetricsFactory)
+
+      scheduler
+    }
 
     it "sets the worker factory" do
-      expect(field(builder, "recordProcessorFactory")).to_not eq(nil)
-    end
-
-    it "sets the config" do
-      kinesis.register
-      config = field(builder, "config")
-      expect(config).to eq(kinesis.kcl_config)
+      expect(field(scheduler, "processorConfig").shardRecordProcessorFactory).to_not eq(nil)
     end
 
     it "disables metric tracking by default" do
-      expect(field(builder, "metricsFactory")).to be_kind_of(com.amazonaws.services.kinesis.metrics.impl::NullMetricsFactory)
+      expect(field(scheduler, "metricsFactory")).to be_kind_of(software.amazon.kinesis.metrics::NullMetricsFactory)
     end
 
     context "cloudwatch" do
@@ -209,9 +178,18 @@ RSpec.describe "inputs/kinesis" do
       it "uses cloudwatch metrics if specified" do
         # since the behaviour is enclosed on private methods it is not testable. So here
         # the expected value can be tested, not the result associated to set this value
-        expect(field(builder, "metricsFactory")).to eq(nil)
+        expect(field(scheduler, "metricsFactory")).to be_kind_of(software.amazon.kinesis.metrics::CloudWatchMetricsFactory)
       end
     end
+  end
+
+  def software
+    Java::Software
+  end
+
+  def get_client_configuration(client)
+    handler = field(client, 'clientHandler')
+    field(handler, 'clientConfiguration')
   end
 
   def field(obj, name)


### PR DESCRIPTION
Resolves #46.

The way KCL is configured has changed between v1 and v2, configuration values are stored in separate POJOs now so there can't just be a single `additional_options` block that allows everything to be changed.

Since the consumer now has to instantiate the clients it wants to use itself there will have to be separate configuration values for setting things like Kinesis endpoint (so there has been a regression on items like #49 since #51) - `endpointOverride` takes a `URI` and unsure how we'd handle that without adding `kinesis_endpoint`, `cloudwatch_endpoint`, etc configuration values separately, open to any suggestions if that should be in the scope of this PR.

Note: this is a breaking change as it requires the following extra permissions to be added to the IAM role being assumed by logstash:

* [`SubscribeToShard`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShard.html)
* [`DescribeStreamSummary`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStreamSummary.html)
* [`DescribeStreamConsumer`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStreamConsumer.html)
* [`RegisterStreamConsumer`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html)