### PR TITLE
Use assumed role for dynamodb and cloudwatch too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+  - Changed role assumption to also assume role for interactions with dynamodb and cloudwatch [#66](https://github.com/logstash-plugins/logstash-input-kinesis/pull/66)
+
 ## 2.0.11
   - Added the ability to assume a role [#40](https://github.com/logstash-plugins/logstash-input-kinesis/pull/40)
 

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -110,9 +110,7 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
     @kcl_config = KCL::KinesisClientLibConfiguration.new(
       @application_name,
       @kinesis_stream_name,
-      kinesis_creds, # credential provider for accessing the kinesis stream
-      creds, # credential provider for creating / accessing the dynamo table
-      creds, # credential provider for cloudwatch metrics
+      kinesis_creds, # credential provider for Kinesis, DynamoDB and Cloudwatch access
       worker_id).
         withInitialPositionInStream(initial_position_in_stream).
         withRegionName(@region)

--- a/lib/logstash/inputs/kinesis/version.rb
+++ b/lib/logstash/inputs/kinesis/version.rb
@@ -2,7 +2,7 @@
 module Logstash
   module Input
     module Kinesis
-      VERSION = "2.0.11"
+      VERSION = "2.1.0"
     end
   end
 end

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe "inputs/kinesis" do
   it "uses STS for accessing the kinesis stream if role_arn is specified" do
     kinesis_with_role_arn.register
     expect(kinesis_with_role_arn.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider")
-    expect(kinesis_with_role_arn.kcl_config.get_dynamo_db_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
-    expect(kinesis_with_role_arn.kcl_config.get_cloud_watch_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+    expect(kinesis_with_role_arn.kcl_config.get_dynamo_db_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider")
+    expect(kinesis_with_role_arn.kcl_config.get_cloud_watch_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider")
   end
 
   subject!(:kinesis_with_latest) { LogStash::Inputs::Kinesis.new(config_with_latest) }


### PR DESCRIPTION
Currently when assuming a role, it is only specified for Kinesis operations,
but should also be used for DynamoDB and Cloudwatch operations.

Fixes #65 