### PR TITLE
Allow submitted metadata

### DIFF
--- a/lib/logstash/inputs/kinesis/worker.rb
+++ b/lib/logstash/inputs/kinesis/worker.rb
@@ -49,7 +49,7 @@ class LogStash::Inputs::Kinesis::Worker
     metadata = build_metadata(record)
     @codec.decode(raw) do |event|
       @decorator.call(event)
-      event.set('@metadata', metadata)
+      event.set('@metadata', event.get('@metadata').merge(metadata))
       @output_queue << event
     end
   rescue => error

--- a/spec/inputs/kinesis/worker_spec.rb
+++ b/spec/inputs/kinesis/worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "LogStash::Inputs::Kinesis::Worker" do
           ),
           record(
             {
-              '@metadata': {
+              '@metadata' => {
                 forwarded: 'record2'
               },
               id: "record2",
@@ -63,7 +63,7 @@ RSpec.describe "LogStash::Inputs::Kinesis::Worker" do
         .withRecords(java.util.Arrays.asList([
           record(
             {
-              '@metadata': {
+              '@metadata' => {
                 forwarded: 'record3',
                 partition_key: 'invalid_key'
               },


### PR DESCRIPTION
This will allow the Kinesis events to include event metadata and instead of overwriting it merge the additional data into it.

fixes #64 