### PR TITLE
Upgrade AWS libs to support running in AWS EKS

### DIFF
--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.9.2'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.414'"
+  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.13.3'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.745'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.745'"
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 


### PR DESCRIPTION
This PR upgrades AWS dependencies to add the support for the WebIdentityTokenCredentialsProvider credentials provider.

Any objections? Can someone help me test the change? 😄 

Fixes #76.