### PR TITLE
Upgrade AWS SDK for WebIdentityTokenCredentialsProvider Support

### DIFF
--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.platform      = 'java'
 
-  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.9.2'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.414'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.414'"
+  spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.13.3'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.770'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.770'"
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.platform      = 'java'
 
   spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.13.3'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.770'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.770'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.788'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.788'"
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 

--- a/logstash-input-kinesis.gemspec
+++ b/logstash-input-kinesis.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.platform      = 'java'
 
   spec.requirements << "jar 'com.amazonaws:amazon-kinesis-client', '1.13.3'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.788'"
-  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.788'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-core', '1.11.1034'"
+  spec.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.1034'"
 
   spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 


### PR DESCRIPTION
This upgrades AWS SDK dependencies to add WebIdentityTokenCredentialsProvider authentication support. This is required to deploy in Amazon EKS using IAM Roles for Service Accounts.

Fixes #76. 

Closes #77. Closes #80. This duplicates those PRs, just with the build now passing and slightly newer dependencies.